### PR TITLE
fix: added additional go build flags to solve fork/exec no such file …

### DIFF
--- a/go-example-extension/Makefile
+++ b/go-example-extension/Makefile
@@ -1,8 +1,8 @@
 build:
-	GOOS=linux GOARCH=amd64 go build -o bin/extensions/go-example-extension main.go
+	GOOS=linux GOARCH=amd64 go build -v -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo -o bin/extensions/go-example-extension main.go
 
 build-GoExampleExtensionLayer:
-	GOOS=linux GOARCH=amd64 go build -o $(ARTIFACTS_DIR)/extensions/go-example-extension main.go
+	GOOS=linux GOARCH=amd64 go build -v -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo -o $(ARTIFACTS_DIR)/extensions/go-example-extension main.go
 	chmod +x $(ARTIFACTS_DIR)/extensions/go-example-extension
 
 run-GoExampleExtensionLayer:

--- a/go-example-extension/README.md
+++ b/go-example-extension/README.md
@@ -9,7 +9,7 @@ To run this example, you will need to ensure that your build architecture matche
 Building and saving package into a `bin/extensions` directory:
 ```bash
 $ cd go-example-extension
-$ GOOS=linux GOARCH=amd64 go build -o bin/extensions/go-example-extension main.go
+$ GOOS=linux GOARCH=amd64 go build -v -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo -o bin/extensions/go-example-extension main.go
 $ chmod +x bin/extensions/go-example-extension
 ```
 

--- a/go-example-ipc-extension/README.md
+++ b/go-example-ipc-extension/README.md
@@ -14,7 +14,7 @@ To run this example, you will need to ensure that your build architecture matche
 Building and saving package into a `bin/extensions` directory:
 ```bash
 $ cd go-example-ipc-extension
-$ GOOS=linux GOARCH=amd64 go build -o bin/extensions/go-example-ipc-extension main.go
+$ GOOS=linux GOARCH=amd64 go build -v -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo -o bin/extensions/go-example-ipc-extension main.go
 $ chmod +x bin/extensions/go-example-ipc-extension
 ```
 

--- a/go-example-logs-api-extension/README.md
+++ b/go-example-logs-api-extension/README.md
@@ -18,7 +18,7 @@ To run this example, you will need to ensure that your build architecture matche
 Building and saving package into a `bin/extensions` directory:
 ```bash
 $ cd go-example-logs-api-extension
-$ GOOS=linux GOARCH=amd64 go build -o bin/extensions/go-example-logs-api-extension main.go
+$ GOOS=linux GOARCH=amd64 go build -v -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo -o bin/extensions/go-example-logs-api-extension main.go
 $ chmod +x bin/extensions/go-example-logs-api-extension
 ```
 


### PR DESCRIPTION
…or directory error


*Description of changes:*
Added additional go build flags to solve the following error when executing the lambda function:
`Error: fork/exec /opt/extensions/go-example-extension: no such file or directory`

Issue in another project describing the problem / solution: https://github.com/serverless/serverless/issues/4710


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
