### PR TITLE
add execute permssions

### DIFF
--- a/s3-logs-extension-demo-container-image/extension/Dockerfile
+++ b/s3-logs-extension-demo-container-image/extension/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.8-alpine AS installer
 COPY extensionssrc /opt/
 COPY extensionssrc/requirements.txt /opt/
 RUN pip install -r /opt/requirements.txt -t /opt/extensions/lib
+WORKDIR /opt/extensions
+RUN chmod 755 *.py
 
 FROM scratch AS base
 WORKDIR /opt/extensions


### PR DESCRIPTION
This update resolves issue where you might get permission denied errors

Issue:
when running the example, I recieved the error
Error: fork/exec /opt/extensions/logs_api_http_extension.py: permission denied
Extension.LaunchError 

Description of changes: This change adds execute permissions which resolves the above issue



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
