### PR TITLE
Added missing create-secret command

### DIFF
--- a/cache-extension-demo/README.md
+++ b/cache-extension-demo/README.md
@@ -114,7 +114,7 @@ aws ssm put-parameter \
 Create a new secret in AWS Secrets Manager using the following command
 
 ```bash
-aws secretsmanager \
+aws secretsmanager create-secret \
     --name "secret_info" \
     --secret-string "Hello World"
 ```


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Added missing `create-secret` parameter to secrets manager command in README file for the `cache-extension-demo`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
