### PR TITLE
feat: implement sendLogs to ElasticSearch & fix node-fetch module issue

### DIFF
--- a/nodejs-example-logs-api-extension/.gitignore
+++ b/nodejs-example-logs-api-extension/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 # zip
 *.zip
+nodejs-example-logs-api-extension/node_modules

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -13,6 +13,8 @@ function listen(address, port) {
                 console.log('Logs listener received: ' + body);
                 try {
                     let batch = JSON.parse(body);
+                    console.log('DEBUG body:', body);
+                    console.log('DEBUG batch:', batch);
                     if (batch.length > 0) {
                         logsQueue.push( ...batch );
                     }

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
@@ -2,17 +2,14 @@
 const { register, next } = require('./extensions-api');
 const { subscribe } = require('./logs-api');
 const { listen } = require('./http-listener');
-const AWS = require('aws-sdk');
-const s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const https = require('https');
 
 /**
 
 Note: 
 
-- This is a simple example extension to make you help start investigating the Lambda Runtime Logs API.
-This code is not production ready, and it has never intended to be. Use it with your own discretion after you tested
-it thoroughly.  
-
+- This is a simple example extension to help you start investigating the Lambda Runtime Logs API.
+- It sends the Logs captured at runtime to elastic search without adding any latency as the extensions processing happens async in nature
 - Because of the asynchronous nature of the system, it is possible that logs for one invoke are
 processed during the next invoke slice. Likewise, it is possible that logs for the last invoke are processed during
 the SHUTDOWN event.
@@ -20,48 +17,44 @@ the SHUTDOWN event.
 */
 
 const EventType = {
-    INVOKE: 'INVOKE',
-    SHUTDOWN: 'SHUTDOWN',
+  INVOKE: 'INVOKE',
+  SHUTDOWN: 'SHUTDOWN',
 };
 
 function handleShutdown(event) {
-    console.log('shutdown', { event });
-    process.exit(0);
+  console.log('shutdown', { event });
+  process.exit(0);
 }
 
 function handleInvoke(event) {
-    console.log('invoke');
+  console.log('invoke');
 }
 
-const LOCAL_DEBUGGING_IP = "0.0.0.0";
-const RECEIVER_NAME = "sandbox";
+const LOCAL_DEBUGGING_IP = '0.0.0.0';
+const RECEIVER_NAME = 'sandbox';
 
 async function receiverAddress() {
-    return (process.env.AWS_SAM_LOCAL === 'true')
-        ? LOCAL_DEBUGGING_IP
-        : RECEIVER_NAME;
+  return process.env.AWS_SAM_LOCAL === 'true' ? LOCAL_DEBUGGING_IP : RECEIVER_NAME;
 }
 
-const BUCKET_NAME = process.env.LOGS_S3_BUCKET_NAME;
-const FUNCTION_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME;
+const ELASTICSEARCH_ENDPOINT = process.env.ELASTICSEARCH_ADD_DOC_ENDPOINT || `https://${process.env.ES_ENDPOINT}/my-index/_doc`; // Replace with your Elasticsearch insertion endpoint along with <index>/_doc
 
-// Subscribe to platform logs and receive them on ${local_ip}:4243 via HTTP protocol.
 const RECEIVER_PORT = 4243;
-const TIMEOUT_MS = 1000 // Maximum time (in milliseconds) that a batch is buffered.
-const MAX_BYTES = 262144 // Maximum size in bytes that the logs are buffered in memory.
-const MAX_ITEMS = 10000 // Maximum number of events that are buffered in memory.
+const TIMEOUT_MS = 1000; // Maximum time (in milliseconds) that a batch is buffered.
+const MAX_BYTES = 262144; // Maximum size in bytes that the logs are buffered in memory.
+const MAX_ITEMS = 10000; // Maximum number of events that are buffered in memory.
 
 const SUBSCRIPTION_BODY = {
-    "destination":{
-        "protocol": "HTTP",
-        "URI": `http://${RECEIVER_NAME}:${RECEIVER_PORT}`,
-    },
-    "types": ["platform", "function"],
-    "buffering": {
-        "timeoutMs": TIMEOUT_MS,
-        "maxBytes": MAX_BYTES,
-        "maxItems": MAX_ITEMS
-    }
+  destination: {
+      protocol: 'HTTP',
+      URI: `http://${RECEIVER_NAME}:${RECEIVER_PORT}`,
+  },
+  types: ['platform', 'function'],
+  buffering: {
+      timeoutMs: TIMEOUT_MS,
+      maxBytes: MAX_BYTES,
+      maxItems: MAX_ITEMS,
+  },
 };
 
 (async function main() {
@@ -83,39 +76,53 @@ const SUBSCRIPTION_BODY = {
     await subscribe(extensionId, SUBSCRIPTION_BODY, server);
 
     // function for processing collected logs
-    async function uploadLogs() {
-        while (logsQueue.length > 0) {
-            console.log(`collected ${logsQueue.length} log objects`);
-            if (BUCKET_NAME) {
-                const date = (new Date()).toISOString().replace(/[^0-9]/gi,"-").substr(0,23);
-                const key = 'logs/'+FUNCTION_NAME+'/'+date+'.json';
-                console.log("logs uploading: "+key);
-                const params = { Bucket: BUCKET_NAME, Key: key };
-                params.Body = JSON.stringify(logsQueue); // serialize log queue and add to S3 put request
-                logsQueue.splice(0); // clear log queue
-                params.ContentType = 'application/json; charset=utf-8';
-                await s3.putObject(params).promise();
-                console.log("logs sent: "+key);
-            } else {
-                // You can do something else with logs in logsQueue.
-                logsQueue.splice(0); // clear log queue
+    function sendLogsToElasticsearch() {
+        console.log(`collected ${logsQueue.length} log objects`);
+        logsQueue.forEach(log => {
+            try {
+                const postData = JSON.stringify(log);
+                console.log('postdata DEBUG:', postData);
+                const options = {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Content-Length': Buffer.byteLength(postData),
+                    },
+                };
+
+                const req = https.request(ELASTICSEARCH_ENDPOINT, options, (res) => {
+                    console.log(res);
+                    console.log(`Status code: ${res?.statusCode}`);
+                });               
+
+                req.on('error', (error) => {
+                    console.error(`[${this.agent_name}] Error: ${error}`, flush = true);
+                });
+
+                req.write(postData);
+                req.end();
+                console.log('DEBUG: log processing & es exporting complete')
+
+            } catch (error) {
+                console.error(`[${this.agent_name}] Error: ${error}`, flush = true);
             }
-        }
+
+        });
     }
 
-    // execute extensions logic
+    // execute extensions logic to process & export Logs [events captured in the queue]
     while (true) {
         console.log('next');
         const event = await next(extensionId);
 
         switch (event.eventType) {
             case EventType.SHUTDOWN:
-                await uploadLogs(); // upload remaining logs, during shutdown event
+                sendLogsToElasticsearch(); // upload remaining logs, during shutdown event
                 handleShutdown(event);
                 break;
             case EventType.INVOKE:
                 handleInvoke(event);
-                await uploadLogs(); // upload queued logs, during invoke event
+                sendLogsToElasticsearch(); // send queued logs to Elasticsearch, during invoke event
                 break;
             default:
                 throw new Error('unknown event: ' + event.eventType);

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/logs-api.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/logs-api.js
@@ -1,31 +1,53 @@
-const fetch = require('node-fetch');
+const http = require('http');
 
 const baseUrl = `http://${process.env.AWS_LAMBDA_RUNTIME_API}/2020-08-15/logs`;
 
 async function subscribe(extensionId, subscriptionBody, server) {
-    const res = await fetch(baseUrl, {
-        method: 'put',
-        body: JSON.stringify(subscriptionBody),
+    const requestBody = JSON.stringify(subscriptionBody);
+
+    const options = {
+        method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
             'Lambda-Extension-Identifier': extensionId,
-        }
-    });
+        },
+    };
 
-    switch(res.status) {
-        case 200:
-            console.info('logs subscription ok: ', await res.text());
-            break;
-        case 202:
-            console.warn('WARNING!!! Logs API is not supported! Is this extension running in a local sandbox?');
-            break;
-        default:
-            console.error('logs subscription failed: ', await res.text());
-            break;
-    }
+    return new Promise((resolve, reject) => {
+        const req = http.request(baseUrl, options, (res) => {
+            let data = '';
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                switch (res.statusCode) {
+                    case 200:
+                        console.info('logs subscription ok: ', data);
+                        resolve();
+                        break;
+                    case 202:
+                        console.warn('WARNING!!! Logs API is not supported! Is this extension running in a local sandbox?');
+                        resolve();
+                        break;
+                    default:
+                        console.error('logs subscription failed: ', data);
+                        reject(new Error('Logs subscription failed'));
+                        break;
+                }
+            });
+        });
+
+        req.on('error', (error) => {
+            console.error('logs subscription error:', error);
+            reject(error);
+        });
+
+        req.write(requestBody);
+        req.end();
+    });
 }
 
 module.exports = {
     subscribe,
 };
-

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package-lock.json
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package-lock.json
@@ -1,8 +1,146 @@
 {
   "name": "nodejs-example-logs-api-extension",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "nodejs-example-logs-api-extension",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "aws-sdk": "2.860.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.860.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.860.0.tgz",
+      "integrity": "sha512-BUBWw28PNDhRDnPEnXiPEvgTWD8Iyq5pl9lk/WhXC/vkACJ3aUVe+sicezI1/JQRjLrO3R6w7X20YknVWfAibA==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "aws-sdk": {
       "version": "2.860.0",
@@ -35,32 +173,10 @@
         "isarray": "^1.0.0"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
-    "fetch-blob": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
     },
     "ieee754": {
       "version": "1.1.13",
@@ -70,47 +186,32 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
-        "formdata-polyfill": "^4.0.10"
-      }
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w=="
     },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -120,11 +221,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
     },
     "xml2js": {
       "version": "0.4.19",
@@ -138,7 +234,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
     }
   }
 }

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package.json
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "2.860.0",
-    "node-fetch": "^3.1.1"
+    "aws-sdk": "2.860.0"
   }
 }


### PR DESCRIPTION
*Description of changes:*
-

- For NodeJS Logs API extension, update the processing of subscribed events to send it to Elastic Search instead of S3
- Fix node-fetch module issue encountered while deploying this on higher node versions


