### PR TITLE
Fix bug in telemetry api extension dispatcher

### DIFF
--- a/go-example-telemetry-api-extension/telemetryApi/dispatcher.go
+++ b/go-example-telemetry-api-extension/telemetryApi/dispatcher.go
@@ -51,7 +51,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, logEventsQueue *queue.Queue, 
 		_, err = d.httpClient.Do(req)
 		if err != nil {
 			l.Error("[dispatcher:Dispatch] Failed to dispatch, returning to queue:", err)
-			for logEntry := range logEntries {
+			for _, logEntry := range logEntries {
 				logEventsQueue.Put(logEntry)
 			}
 		}


### PR DESCRIPTION
The dispatcher in the Telemetry API extension has a bug. When putting log events back into the queue, we are putting back the index of the event instead of the actual event.

i.e. We are putting back `0, 1, 2, ... ` (integers) in the queue instead of `logEvents[0], logEvents[1] ...`.

In this PR I am fixing this bug.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
