### PR TITLE
Scan crash dumps every 30 seconds, instead of checking once.

### DIFF
--- a/go-example-crash-uploader-extension/.gitignore
+++ b/go-example-crash-uploader-extension/.gitignore
@@ -1,1 +1,2 @@
 bin/
+go-example-crash-uploader-extension

--- a/go-example-crash-uploader-extension/main.go
+++ b/go-example-crash-uploader-extension/main.go
@@ -90,6 +90,8 @@ func processEvents(ctx context.Context) {
 				return
 			} else if res.EventType == extension.Invoke {
 				requestID = res.RequestID
+
+				// trigger scan again
 			}
 		}
 	}

--- a/go-example-crash-uploader-extension/pack.sh
+++ b/go-example-crash-uploader-extension/pack.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+    rm -rf bin
+    mkdir -p bin
+
+    ( pack_one amd64 )
+    ( pack_one arm64 )
+}
+
+pack_one() {
+    local -r arch=$1
+
+    rm -rf "bin/$arch/extensions/"
+    mkdir -p "bin/$arch/extensions/"
+
+    echo "Building $arch..."
+    GOPROXY=direct GOOS=linux GOARCH=$arch go build -o "bin/$arch/extensions/go-example-crash-uploader-extension"
+    chmod +x "bin/$arch/extensions/go-example-crash-uploader-extension"
+
+    echo "Packing $arch..."
+    cd "bin/$arch"
+    ls -alh extensions/go-example-crash-uploader-extension
+    zip -r9 "../extension.$arch.zip" extensions
+    ls -alh "../extension.$arch.zip"
+
+    if [[ "${PUBLISH:-}" == "1" ]]; then
+        echo "Publishing for $arch..."
+        aws lambda publish-layer-version \
+            --layer-name "crash-uploader-$arch" \
+            --region us-west-2 \
+            --zip-file  "fileb://../extension.$arch.zip"
+    fi
+}
+
+main "$@"

--- a/go-example-crash-uploader-extension/use-aws-sdk.go
+++ b/go-example-crash-uploader-extension/use-aws-sdk.go
@@ -4,13 +4,10 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"os"
-	"path"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -37,68 +34,4 @@ func createS3Client(creds credentials.Value) (*s3.S3, error) {
 	}
 	svc := s3.New(sess)
 	return svc, nil
-}
-
-func createMultipartUpload(svc *s3.S3, s3bucket string, filename string) (*s3.CreateMultipartUploadOutput, error) {
-	input := &s3.CreateMultipartUploadInput{
-		Bucket: aws.String(s3bucket),
-		Key:    aws.String(path.Base(filename)),
-	}
-	resp, err := svc.CreateMultipartUpload(input)
-	return resp, err
-}
-
-func uploadPart(svc *s3.S3, resp *s3.CreateMultipartUploadOutput, fileChunk []byte, partNumber int) (*s3.CompletedPart, error) {
-	partInput := &s3.UploadPartInput{
-		Body:          bytes.NewReader(fileChunk),
-		Bucket:        resp.Bucket,
-		Key:           resp.Key,
-		PartNumber:    aws.Int64(int64(partNumber)),
-		UploadId:      resp.UploadId,
-		ContentLength: aws.Int64(int64(len(fileChunk))),
-	}
-
-	tryNum := 1
-	for {
-		uploadResult, err := svc.UploadPart(partInput)
-		if err != nil {
-			if tryNum >= 3 {
-				if aerr, ok := err.(awserr.Error); ok {
-					return nil, aerr
-				}
-				return nil, err
-			}
-			tryNum++
-		} else {
-			return &s3.CompletedPart{
-				ETag:       uploadResult.ETag,
-				PartNumber: aws.Int64(int64(partNumber)),
-			}, nil
-		}
-	}
-}
-
-func abortMultipartUpload(svc *s3.S3, resp *s3.CreateMultipartUploadOutput) error {
-	abortInput := &s3.AbortMultipartUploadInput{
-		Bucket:   resp.Bucket,
-		Key:      resp.Key,
-		UploadId: resp.UploadId,
-	}
-	_, err := svc.AbortMultipartUpload(abortInput)
-	return err
-}
-
-func completeMultipartUpload(svc *s3.S3, resp *s3.CreateMultipartUploadOutput, completedParts []*s3.CompletedPart) (*s3.CompleteMultipartUploadOutput, error) {
-	completeInput := &s3.CompleteMultipartUploadInput{
-		Bucket:   resp.Bucket,
-		Key:      resp.Key,
-		UploadId: resp.UploadId,
-		MultipartUpload: &s3.CompletedMultipartUpload{
-			Parts: completedParts,
-		},
-	}
-
-	completedOutput, err := svc.CompleteMultipartUpload(completeInput)
-
-	return completedOutput, err
 }


### PR DESCRIPTION
In `go-example-crash-uploader-extension`, scan crash dumps every 30 seconds, instead of checking only once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
